### PR TITLE
修复 RunInstances 接口

### DIFF
--- a/lib/config.json
+++ b/lib/config.json
@@ -17,7 +17,7 @@
         },
         "RunInstances": {
             "required": ["image_id", "zone"], 
-            "optional": ["instance_type", "count", "instance_name", "login_mode", "login_keypair", "login_passwd", "vxnets.n", "security_group"]
+            "optional": ["instance_type", "memory", "cpu", "count", "instance_name", "login_mode", "login_keypair", "login_passwd", "vxnets.n", "security_group"]
         },
         "TerminateInstances": {"required": ["instances.n", "zone"], "optional": []},
         "StartInstances": {"required": ["instances.n", "zone"], "optional": []},


### PR DESCRIPTION
- RunInstances 接口选项:  "memory", "cpu" 选项

https://docs.qingcloud.com/api/instance/run_instances.html
主机类型，有效值请参考 Instance Types
如果请求中指定了 instance_type，cpu 和 memory 参数可略过。
如果请求中没有 instance_type，则 cpu 和 memory 参数必须指定。
如果请求参数中既有 instance_type，又有 cpu 和 memory，则以 cpu, memory 的值为准。
